### PR TITLE
docs: fix simple typo, vaules -> values

### DIFF
--- a/nn.py
+++ b/nn.py
@@ -79,7 +79,7 @@ class NN:
         self.wi = makeMatrix(self.ni, self.nh)
         self.wo = makeMatrix(self.nh, self.no)
         
-        # set them to random vaules
+        # set them to random values
         for i in range(self.ni):
             for j in range(self.nh):
                 self.wi[i][j] = rand(-1, 1)


### PR DESCRIPTION
There is a small typo in nn.py.

Should read `values` rather than `vaules`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md